### PR TITLE
Add transformation scenario to plugin repo

### DIFF
--- a/DITA-Map-Metrics-Report.scenarios
+++ b/DITA-Map-Metrics-Report.scenarios
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serialized xml:space="preserve">
+	<serializableOrderedMap>
+		<entry>
+			<String>scenarios</String>
+			<scenario-array>
+				<ditaScenario>
+					<field name="useXEP">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="useAntennaHouse">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="baseDir">
+						<String>${cfd}</String>
+					</field>
+					<field name="outputDir">
+						<String>${cfd}/out/metrics-report</String>
+					</field>
+					<field name="tempDir">
+						<String>${cfd}/temp/metrics-report</String>
+					</field>
+					<field name="transtype">
+						<String>metrics-report</String>
+					</field>
+					<field name="filters">
+						<ditavalFilters>
+							<field name="useDitavalFilePath">
+								<Boolean>false</Boolean>
+							</field>
+							<field name="useAppliedConditionSet">
+								<Boolean>true</Boolean>
+							</field>
+							<field name="appliedConditionSet">
+								<null/>
+							</field>
+							<field name="ditavalFilePath">
+								<null/>
+							</field>
+							<field name="simpleFiltersList">
+								<list/>
+							</field>
+						</ditavalFilters>
+					</field>
+					<field name="addOxygenJars">
+						<Boolean>true</Boolean>
+					</field>
+					<field name="skinCssFile">
+						<null/>
+					</field>
+					<field name="lastCustomSkinCssPath">
+						<null/>
+					</field>
+					<field name="webhelpResponsiveTemplate">
+						<null/>
+					</field>
+					<field name="publishingTemplateDataPO">
+						<null/>
+					</field>
+					<field name="oxygenFeedbackPO">
+						<null/>
+					</field>
+					<field name="additionalAntArgs">
+						<String></String>
+					</field>
+					<field name="buildTarget">
+						<String></String>
+					</field>
+					<field name="buildFilePath">
+						<String></String>
+					</field>
+					<field name="ditaParams">
+						<list>
+							<ditaParameter>
+								<field name="name">
+									<String>args.input</String>
+								</field>
+								<field name="description">
+									<String></String>
+								</field>
+								<field name="value">
+									<String>${cf}</String>
+								</field>
+								<field name="defaultValue">
+									<null/>
+								</field>
+								<field name="type">
+									<Integer>5</Integer>
+								</field>
+								<field name="possibleValues">
+									<null/>
+								</field>
+								<field name="possibleValuesDescriptions">
+									<null/>
+								</field>
+							</ditaParameter>
+							<ditaParameter>
+								<field name="name">
+									<String>dita.dir</String>
+								</field>
+								<field name="description">
+									<String></String>
+								</field>
+								<field name="value">
+									<String>${configured.ditaot.dir}</String>
+								</field>
+								<field name="defaultValue">
+									<null/>
+								</field>
+								<field name="type">
+									<Integer>3</Integer>
+								</field>
+								<field name="possibleValues">
+									<null/>
+								</field>
+								<field name="possibleValuesDescriptions">
+									<null/>
+								</field>
+							</ditaParameter>
+						</list>
+					</field>
+					<field name="jvmArgs">
+						<String></String>
+					</field>
+					<field name="useCustomJavaHome">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="customJavaHomeDir">
+						<String></String>
+					</field>
+					<field name="useCustomANTHome">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="customANTHomeDir">
+						<String></String>
+					</field>
+					<field name="workingDir">
+						<null/>
+					</field>
+					<field name="showConsoleAlways">
+						<Boolean>true</Boolean>
+					</field>
+					<field name="advancedOptionsMap">
+						<null/>
+					</field>
+					<field name="name">
+						<String>DITA Map Metrics Report</String>
+					</field>
+					<field name="baseURL">
+						<null/>
+					</field>
+					<field name="footerURL">
+						<null/>
+					</field>
+					<field name="fOPMethod">
+						<null/>
+					</field>
+					<field name="fOProcessorName">
+						<null/>
+					</field>
+					<field name="headerURL">
+						<null/>
+					</field>
+					<field name="inputXSLURL">
+						<null/>
+					</field>
+					<field name="inputXMLURL">
+						<null/>
+					</field>
+					<field name="defaultScenario">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="isFOPPerforming">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="type">
+						<String>DITAMAP</String>
+					</field>
+					<field name="saveAs">
+						<Boolean>true</Boolean>
+					</field>
+					<field name="openInBrowser">
+						<Boolean>true</Boolean>
+					</field>
+					<field name="outputResource">
+						<null/>
+					</field>
+					<field name="openOtherLocationInBrowser">
+						<Boolean>true</Boolean>
+					</field>
+					<field name="locationToOpenInBrowserURL">
+						<String>${cfd}/out/metrics-report/report.html</String>
+					</field>
+					<field name="openInEditor">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="showInHTMLPane">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="showInXMLPane">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="showInSVGPane">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="showInResultSetPane">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="useXSLTInput">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="xsltParams">
+						<list/>
+					</field>
+					<field name="cascadingStylesheets">
+						<String-array/>
+					</field>
+					<field name="xslTransformer">
+						<String>DITA-OT</String>
+					</field>
+					<field name="extensionURLs">
+						<String-array/>
+					</field>
+				</ditaScenario>
+			</scenario-array>
+		</entry>
+		<entry>
+			<String>scenarios.load.from.project</String>
+			<Boolean>false</Boolean>
+		</entry>
+	</serializableOrderedMap>
+</serialized>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ A short description of each reported metric can be found below:
   - Tables containing list of largest and smallest topics and the number of words each one used.
   - Table containing a listing of all links to resources outside of the project.
 
+## Importing the transformation scenario
+
+The plugin repository includes a transformation scenario that you can import to your oXygen project file to make it easier to generate metrics reports.
+
+1. Open your project’s root map in the **DITA Maps Manager** view.
+2. From the menu, select **DITA Maps > Configure Transformation Scenario(s)**.
+3. Click the ![settings](https://user-images.githubusercontent.com/129995/135727362-059f3c05-6218-47ed-9508-6136fcc6e1dd.png) **Settings** menu in the upper right corner of the **Configure Transformation Scenario(s)** dialog.
+4. Select **Import Scenarios**.
+5. Navigate to your local clone of the `dita-metrics-report` plugin repository.
+6. Select the `DITA-Map-Metrics-Report.scenarios` file.
+
+This adds a new _DITA Maps Metrics Report_ scenario to your project, with the following settings:
+
+- The DITA-OT parameter `args.input` is set to `${cf}` _(current file)_.
+- The `dita.dir` parameter is set to `${configured.ditaot.dir}` to use the DITA Open Toolkit installation specified in the oXygen [DITA Preferences](https://www.oxygenxml.com/doc/versions/23.1/ug-editor/topics/preferences-dita.html).
+- The output directory is set to `${cfd}/out/metrics-report` to generate the report in the `/out/metrics-report/` subfolder of the current file directory.
+
 # Visualizing the evolution of metrics between different versions of the documentation
 
 You can try to generate metrics for multiple previous versions of your user's manual and then try to see how various indicators evolved. In order for this to work, you first need to use the "metrics-report-xml" transtype contributed by this plugin to create an XML report for each of the previous user guide versions that you are interested in comparing. You will need version control support to checkout the contents of your user's manual at a specific version.


### PR DESCRIPTION
Fixes #6.

In addition to the transformation scenario, this PR also adds a section to the README that explains how to import the scenario to an oXygen project _(quoted below for convenience)_.

* * *

## Importing the transformation scenario

The plugin repository includes a transformation scenario that you can import to your oXygen project file to make it easier to generate metrics reports.

1. Open your project’s root map in the **DITA Maps Manager** view.
2. From the menu, select **DITA Maps > Configure Transformation Scenario(s)**.
3. Click the ![settings](https://user-images.githubusercontent.com/129995/135727362-059f3c05-6218-47ed-9508-6136fcc6e1dd.png) **Settings** menu in the upper right corner of the **Configure Transformation Scenario(s)** dialog.
4. Select **Import Scenarios**.
5. Navigate to your local clone of the `dita-metrics-report` plugin repository.
6. Select the `DITA-Map-Metrics-Report.scenarios` file.

This adds a new _DITA Maps Metrics Report_ scenario to your project, with the following settings:

- The DITA-OT parameter `args.input` is set to `${cf}` _(current file)_.
- The `dita.dir` parameter is set to `${configured.ditaot.dir}` to use the DITA Open Toolkit installation specified in the oXygen [DITA Preferences](https://www.oxygenxml.com/doc/versions/23.1/ug-editor/topics/preferences-dita.html).
- The output directory is set to `${cfd}/out/metrics-report` to generate the report in the `/out/metrics-report/` subfolder of the current file directory.


